### PR TITLE
Mark some globals as extern to fix compilation

### DIFF
--- a/pd/src/g_canvas.c
+++ b/pd/src/g_canvas.c
@@ -16,6 +16,11 @@ to be different but are now unified except for some fossilized names.) */
 #include <string.h>
 #include <math.h>
 
+t_garray *array_garray;
+t_class *preset_hub_class;
+t_class *preset_node_class;
+int array_joc;
+
 extern int do_not_redraw;
 extern void canvas_drawconnection(t_canvas *x, int lx1, int ly1, int lx2, int ly2, t_int tag, int issignal);
 extern void canvas_updateconnection(t_canvas *x, int lx1, int ly1, int lx2, int ly2, t_int tag);

--- a/pd/src/g_canvas.h
+++ b/pd/src/g_canvas.h
@@ -152,8 +152,8 @@ typedef struct _arrayvis
     t_garray *av_garray;            /* owning structure */    
 } t_arrayvis;
 
-t_garray* array_garray;    /* used for sending bangs when
-                              array is changed  via gui */
+extern t_garray* array_garray;    /* used for sending bangs when
+                                     array is changed  via gui */
 
 /* the t_tick structure describes where to draw x and y "ticks" for a glist */
 
@@ -242,8 +242,8 @@ struct _glist
 // this is where all the classes capable of being controlled via preset should be defined
 
 // preset objects
-t_class *preset_hub_class;
-t_class *preset_node_class;
+extern t_class *preset_hub_class;
+extern t_class *preset_node_class;
 
 // special case objects
 extern t_class *print_class;
@@ -641,7 +641,7 @@ EXTERN void array_resize(t_array *x, int n);
 EXTERN void array_free(t_array *x);
 EXTERN void array_redraw(t_array *a, t_glist *glist);
 EXTERN void array_resize_and_redraw(t_array *array, t_glist *glist, int n);
-int array_joc; /* for "jump on click" array inside a graph */
+extern int array_joc; /* for "jump on click" array inside a graph */
 
 /* --------------------- gpointers and stubs ---------------- */
 EXTERN t_gstub *gstub_new(t_glist *gl, t_array *a);


### PR DESCRIPTION
This happened if g_canvas.h was included more than once.