### PR TITLE
continue previous downloads

### DIFF
--- a/l2ork_addons/tar_em_up.sh
+++ b/l2ork_addons/tar_em_up.sh
@@ -200,7 +200,7 @@ if [ ! -d "../pd/nw/nw" ]; then
 	nwjs_url=${nwjs_url}/$nwjs_filename
 	echo "Fetching the nwjs binary from"
 	echo "$nwjs_url"
-	wget -nv $nwjs_url
+	wget -cnv $nwjs_url
 	if [[ $os == "win" || $os == "osx" ]]; then
 		unzip $nwjs_filename
 	else
@@ -223,7 +223,7 @@ fi
 if [[ $os == "win" ]]; then
 	if [ ! -d "../pd/lib" ]; then
 		mkdir ../pd/lib
-		wget http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip
+		wget -c http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip
 		unzip asiosdk2.3.zip
 		mv ASIOSDK2.3 ../pd/lib
 	fi


### PR DESCRIPTION
Hi there,

I adjusted the build script to continue previous downloads of nwjs and asiosdk (and do not restart). This should make it both faster and avoid clutter (when run multiple times).

Cheers,
tpltnt