### PR TITLE
Adds support for touch events

### DIFF
--- a/pd/nw/pd_canvas.js
+++ b/pd/nw/pd_canvas.js
@@ -36,15 +36,15 @@ function nw_window_zoom(name, delta) {
     }
 }
 
-var canvas_events = (function() {
+var canvas_events = (function () {
     var name,
         state,
         scalar_draggables = {}, // scalar child with the "drag" event enabled
-        draggable_elem,         // last scalar we dragged
-        draggable_label,        // kluge for handling [cnv] label/size anchors
-        last_draggable_x,       // last x coord for the element we're dragging
-        last_draggable_y,       // last y
-        previous_state = "none", /* last state, excluding explicit 'none' */
+        draggable_elem, // last scalar we dragged
+        draggable_label, // kluge for handling [cnv] label/size anchors
+        last_draggable_x, // last x coord for the element we're dragging
+        last_draggable_y, // last y
+        previous_state = "none" /* last state, excluding explicit 'none' */,
         match_words_state = false,
         last_dropdown_menu_x,
         last_dropdown_menu_y,
@@ -59,12 +59,14 @@ var canvas_events = (function() {
                 if (scalar_draggables[ret.id]) {
                     return ret;
                 }
-                ret = (ret.parentNode && ret.parentNode.tagName === "g") ?
-                    ret.parentNode : null;
+                ret =
+                    ret.parentNode && ret.parentNode.tagName === "g"
+                        ? ret.parentNode
+                        : null;
             }
             return ret; // returning null if no parent group has a listener
         },
-        target_is_scrollbar = function(evt) {
+        target_is_scrollbar = function (evt) {
             // Don't send the event to Pd if we click on the scrollbars.
             // This is a bit fragile because we're suppressing on
             // HTMLHtmlElement which is too broad...
@@ -74,11 +76,16 @@ var canvas_events = (function() {
                 return 0;
             }
         },
-        text_to_normalized_svg_path = function(text) {
-            text = text.slice(4).trim()  // draw
-                       .slice(4).trim()  // path
-                       .slice(1).trim()  // d
-                       .slice(1).trim(); // =
+        text_to_normalized_svg_path = function (text) {
+            text = text
+                .slice(4)
+                .trim() // draw
+                .slice(4)
+                .trim() // path
+                .slice(1)
+                .trim() // d
+                .slice(1)
+                .trim(); // =
             if (text.slice(0, 1) === '"') {
                 text = text.slice(1);
             }
@@ -86,11 +93,16 @@ var canvas_events = (function() {
                 text = text.slice(0, -1);
             }
             text = pdgui.parse_svg_path(text);
-            return "draw path " + text.reduce(function (prev, curr) {
-                return prev.concat(curr)
-            }).join(" ");
+            return (
+                "draw path " +
+                text
+                    .reduce(function (prev, curr) {
+                        return prev.concat(curr);
+                    })
+                    .join(" ")
+            );
         },
-        text_to_fudi = function(text) {
+        text_to_fudi = function (text) {
             text = text.trim();
             // special case for draw path d="arbitrary path string" ...
             if (text.search(/^draw\s+path\s+d\s*=\s*"/) !== -1) {
@@ -109,9 +121,9 @@ var canvas_events = (function() {
             text = text.replace(/\u0020+/g, " ");
             return text;
         },
-        string_to_array_of_chunks = function(msg) {
-        // Convert a string (FUDI message) to an array of strings small enough
-        // to fit in Pd's socketreceiver buffer of 4096 bytes
+        string_to_array_of_chunks = function (msg) {
+            // Convert a string (FUDI message) to an array of strings small enough
+            // to fit in Pd's socketreceiver buffer of 4096 bytes
             var chunk_max = 1024,
                 max_pd_string = 1000,
                 left,
@@ -127,8 +139,11 @@ var canvas_events = (function() {
                         while (1) {
                             if (left.length < 2) {
                                 pdgui.post("Warning: string truncated:");
-                                pdgui.post(left.toString().
-                                    match(/............................../g).join("\n")
+                                pdgui.post(
+                                    left
+                                        .toString()
+                                        .match(/............................../g)
+                                        .join("\n")
                                 );
                                 break;
                             }
@@ -147,7 +162,7 @@ var canvas_events = (function() {
             }
             return out_array;
         },
-        might_be_a_pd_file = function(stuff_from_clipboard) {
+        might_be_a_pd_file = function (stuff_from_clipboard) {
             // Super-simplistic guess at whether the string from the clipboard
             // starts with Pd code. This is just meant as a convenience so that
             // stuff in the copy buffer that obviously isn't Pd code doesn't get
@@ -155,9 +170,9 @@ var canvas_events = (function() {
             var text = stuff_from_clipboard.trim(),
                 one = text.charAt(0),
                 two = text.charAt(1);
-            return (one === "#" && (two === "N" || two === "X"));
+            return one === "#" && (two === "N" || two === "X");
         },
-        grow_svg_for_element = function(elem) {
+        grow_svg_for_element = function (elem) {
             // See if an element overflows the svg bbox, and
             // enlarge the svg to accommodate it.
             // Note: window.scrollX and window.scrollY might not work
@@ -165,95 +180,120 @@ var canvas_events = (function() {
             var svg = document.getElementById("patchsvg"),
                 elem_bbox = elem.getBoundingClientRect(),
                 svg_viewbox = svg.getAttribute("viewBox").split(" "),
-                w = Math.max(elem_bbox.left + elem_bbox.width + window.scrollX,
-                    svg_viewbox[2]),
-                h = Math.max(elem_bbox.top + elem_bbox.height + window.scrollY,
-                    svg_viewbox[3]);
-            svg.setAttribute("viewBox",
-                [Math.min(elem_bbox.left, svg_viewbox[0]),
-                 Math.min(elem_bbox.top, svg_viewbox[1]),
-                 w,
-                 h
-                ].join(" "));
+                w = Math.max(
+                    elem_bbox.left + elem_bbox.width + window.scrollX,
+                    svg_viewbox[2]
+                ),
+                h = Math.max(
+                    elem_bbox.top + elem_bbox.height + window.scrollY,
+                    svg_viewbox[3]
+                );
+            svg.setAttribute(
+                "viewBox",
+                [
+                    Math.min(elem_bbox.left, svg_viewbox[0]),
+                    Math.min(elem_bbox.top, svg_viewbox[1]),
+                    w,
+                    h
+                ].join(" ")
+            );
             svg.setAttribute("width", w);
             svg.setAttribute("height", h);
         },
-        dropdown_index_to_pd = function(elem) {
+        dropdown_index_to_pd = function (elem) {
             var highlighted = elem.querySelector(".highlighted");
             if (highlighted) {
-                pdgui.pdsend(elem.getAttribute("data-callback"),
-                    highlighted.getAttribute("data-index"));
+                pdgui.pdsend(
+                    elem.getAttribute("data-callback"),
+                    highlighted.getAttribute("data-index")
+                );
             }
         },
-        dropdown_clear_highlight = function() {
+        dropdown_clear_highlight = function () {
             var container = document.querySelector("#dropdown_list"),
                 li_array = container.querySelectorAll("li");
-            Array.prototype.forEach.call(li_array, function(e) {
+            Array.prototype.forEach.call(li_array, function (e) {
                 e.classList.remove("highlighted");
             });
         },
-        dropdown_highlight_elem = function(elem, scroll) {
+        dropdown_highlight_elem = function (elem, scroll) {
             var container = document.querySelector("#dropdown_list");
             if (!elem.classList.contains("highlighted")) {
                 dropdown_clear_highlight();
                 elem.classList.add("highlighted");
                 // Make sure the highlighted element is in view
                 if (scroll) {
-                    if (elem.offsetTop < container.scrollTop
-                        || elem.offsetTop + elem.offsetHeight >
-                            container.scrollTop + container.offsetHeight) {
-                            if (scroll === "up") {
-                                // we can't usse elem.scrollIntoView() here
-                                // because it may also change the scrollbar on
-                                // the document, which in turn could change the
-                                // pageX/pageY, for the mousemove event, which
-                                // in turn would make it impossible for us to
-                                // filter out unnecessary mousemove calls
-                                //    elem.scrollIntoView();
+                    if (
+                        elem.offsetTop < container.scrollTop ||
+                        elem.offsetTop + elem.offsetHeight >
+                        container.scrollTop + container.offsetHeight
+                    ) {
+                        if (scroll === "up") {
+                            // we can't usse elem.scrollIntoView() here
+                            // because it may also change the scrollbar on
+                            // the document, which in turn could change the
+                            // pageX/pageY, for the mousemove event, which
+                            // in turn would make it impossible for us to
+                            // filter out unnecessary mousemove calls
+                            //    elem.scrollIntoView();
                             container.scrollTop = elem.offsetTop;
                         } else if (scroll === "down") {
-                            container.scrollTop = elem.offsetTop + elem.offsetHeight
-                                - container.clientHeight;
+                            container.scrollTop =
+                                elem.offsetTop + elem.offsetHeight - container.clientHeight;
                         }
                     }
                 }
             }
         },
         events = {
-            mousemove: function(evt) {
-                //pdgui.post("x: " + evt.pageX + " y: " + evt.pageY +
+            pointermove: function (evt) {
+                //  pdgui.post("x: " + evt.pageX + " y: " + evt.pageY +
                 //    " modifier: " + (evt.shiftKey + (pdgui.cmd_or_ctrl_key(evt) << 1)));
-                pdgui.pdsend(name, "motion",
-                    (evt.pageX + svg_view.x),
-                    (evt.pageY + svg_view.y),
-                    (evt.shiftKey + (pdgui.cmd_or_ctrl_key(evt) << 1))
+                let [pointer_x, pointer_y] = evt.type === "touchmove"
+                    ? [evt.touches[0].pageX, evt.touches[0].pageY]
+                    : [evt.pageX, evt.pageY];
+
+                pdgui.pdsend(
+                    name,
+                    "motion",
+                    pointer_x + svg_view.x,
+                    pointer_y + svg_view.y,
+                    evt.shiftKey + (pdgui.cmd_or_ctrl_key(evt) << 1)
                 );
+
                 evt.stopPropagation();
                 evt.preventDefault();
                 return false;
             },
-            mousedown: function(evt) {
+            pointerdown: function (evt) {
+                let [pointer_x, pointer_y] = evt.type === "touchstart"
+                    ? [evt.touches[0].pageX, evt.touches[0].pageY]
+                    : [evt.pageX, evt.pageY];
+
                 var target_id, resize_type;
+
                 if (target_is_scrollbar(evt)) {
                     return;
-                } else if (evt.target.parentNode &&
-                    evt.target.parentNode.classList
-                        .contains("clickable_resize_handle")) {
-                    draggable_label =
-                        evt.target.parentNode.classList.contains("move_handle");
+                } else if (
+                    evt.target.parentNode &&
+                    evt.target.parentNode.classList.contains("clickable_resize_handle")
+                ) {
+                    draggable_label = evt.target.parentNode.classList.contains(
+                        "move_handle"
+                    );
 
                     // get id ("x123456etcgobj" without the "x" or "gobj")
-                    target_id = (draggable_label ? "_l" : "_s") +
-                        evt.target.parentNode.parentNode.id.slice(0,-4).slice(1);
-                    last_draggable_x = evt.pageX + svg_view.x;
-                    last_draggable_y = evt.pageY + svg_view.y;
+                    target_id =
+                        (draggable_label ? "_l" : "_s") +
+                        evt.target.parentNode.parentNode.id.slice(0, -4).slice(1);
+                    last_draggable_x = pointer_x + svg_view.x;
+                    last_draggable_y = pointer_y + svg_view.y;
 
                     // Nasty-- we have to forward magic values from g_canvas.h
                     // defines in order to get the correct constrain behavior.
                     if (evt.target.classList.contains("constrain_top_right")) {
                         resize_type = 7; // CURSOR_EDITMODE_RESIZE_X
-                    } else if (evt.target.classList
-                        .contains("constrain_bottom_right")) {
+                    } else if (evt.target.classList.contains("constrain_bottom_right")) {
                         resize_type = 10; // CURSOR_EDITMODE_RESIZE_Y
                     } else if (draggable_label) {
                         resize_type = 11; // CURSOR_EDITMODE_MOVE
@@ -267,18 +307,27 @@ var canvas_events = (function() {
                     // drag handle to move the gop red rectangle. Unlike
                     // the label handles, it doesn't get immediately
                     // destroyed upon receiving its callback below.
-                    pdgui.toggle_drag_handle_cursors(evt.target.parentNode,
-                        !!draggable_label, false);
+                    pdgui.toggle_drag_handle_cursors(
+                        evt.target.parentNode,
+                        !!draggable_label,
+                        false
+                    );
 
-                    pdgui.pdsend(target_id, "_click", resize_type,
-                        (evt.pageX + svg_view.x),
-                        (evt.pageY + svg_view.y));
+                    pdgui.post(
+                        target_id,
+                        "_click",
+                        resize_type,
+                        pointer_x + svg_view.x,
+                        pointer_y + svg_view.y
+                    );
                     canvas_events.iemgui_label_drag();
+
                     return;
                 }
+
                 // tk events (and, therefore, Pd events) are one greater
                 // than html5...
-                var b = evt.button + 1;
+                var b = evt.button + 1 || 1;
                 var mod, match_elem;
                 // See if there are any draggable scalar shapes...
                 if (Object.keys(scalar_draggables).length) {
@@ -287,8 +336,8 @@ var canvas_events = (function() {
                     if (match_elem) {
                         // then set some state and turn on the drag events
                         draggable_elem = match_elem;
-                        last_draggable_x = evt.pageX;
-                        last_draggable_y = evt.pageY;
+                        last_draggable_x = pointer_x;
+                        last_draggable_y = pointer_y;
                         canvas_events.scalar_drag();
                     }
                 }
@@ -299,55 +348,62 @@ var canvas_events = (function() {
                     // right-click
                     mod = 8;
                 } else {
-                    mod = (evt.shiftKey + (pdgui.cmd_or_ctrl_key(evt) << 1));
+                    mod = evt.shiftKey + (pdgui.cmd_or_ctrl_key(evt) << 1);
                 }
-                pdgui.pdsend(name, "mouse",
-                    (evt.pageX + svg_view.x),
-                    (evt.pageY + svg_view.y),
-                    b, mod
+                pdgui.pdsend(
+                    name,
+                    "mouse",
+                    pointer_x + svg_view.x,
+                    pointer_y + svg_view.y,
+                    b,
+                    mod
                 );
                 //evt.stopPropagation();
                 //evt.preventDefault();
             },
-            mouseup: function(evt) {
-                //pdgui.post("mouseup: x: " +
-                //    evt.pageX + " y: " + evt.pageY +
-                //    " button: " + (evt.button + 1));
-                pdgui.pdsend(name, "mouseup",
-                    (evt.pageX + svg_view.x),
-                    (evt.pageY + svg_view.y),
-                    (evt.button + 1)
+            pointerup: function (evt) {
+                let [pointer_x, pointer_y] = evt.type === "touchend"
+                    ? [evt.changedTouches[0].pageX, evt.changedTouches[0].pageY]
+                    : [evt.pageX, evt.pageY];
+
+                pdgui.pdsend(
+                    name,
+                    "mouseup",
+                    pointer_x + svg_view.x,
+                    pointer_y + svg_view.y,
+                    evt.button + 1 || 1
                 );
                 evt.stopPropagation();
                 evt.preventDefault();
             },
-            keydown: function(evt) {
+            keydown: function (evt) {
                 pdgui.keydown(name, evt);
                 // prevent the default behavior of scrolling
                 // on arrow keys in editmode
-                if (document.querySelector("#patchsvg")
-                    .classList.contains("editmode")) {
+                if (
+                    document.querySelector("#patchsvg").classList.contains("editmode")
+                ) {
                     if ([32, 37, 38, 39, 40].indexOf(evt.keyCode) > -1) {
                         evt.preventDefault();
                     }
                 }
             },
-            keypress: function(evt) {
+            keypress: function (evt) {
                 pdgui.keypress(name, evt);
                 // Don't do things like scrolling on space, arrow keys, etc.
                 evt.preventDefault();
             },
-            keyup: function(evt) {
+            keyup: function (evt) {
                 pdgui.keyup(name, evt);
                 evt.stopPropagation();
                 evt.preventDefault();
             },
-            text_mousemove: function(evt) {
+            text_mousemove: function (evt) {
                 evt.stopPropagation();
                 //evt.preventDefault();
                 return false;
             },
-            text_mousedown: function(evt) {
+            text_mousedown: function (evt) {
                 if (textbox() !== evt.target && !target_is_scrollbar(evt)) {
                     utils.create_obj();
                     // send a mousedown and mouseup event to Pd to instantiate
@@ -360,19 +416,19 @@ var canvas_events = (function() {
                 //evt.preventDefault();
                 return false;
             },
-            text_mouseup: function(evt) {
+            text_mouseup: function (evt) {
                 //pdgui.post("mouseup target is " +
                 //    evt.target + " and textbox is " + textbox());
                 //evt.stopPropagation();
                 //evt.preventDefault();
                 return false;
             },
-            text_keydown: function(evt) {
+            text_keydown: function (evt) {
                 evt.stopPropagation();
                 //evt.preventDefault();
                 return false;
             },
-            text_keyup: function(evt) {
+            text_keyup: function (evt) {
                 evt.stopPropagation();
                 if (evt.keyCode === 13) {
                     grow_svg_for_element(textbox());
@@ -380,18 +436,21 @@ var canvas_events = (function() {
                 //evt.preventDefault();
                 return false;
             },
-            text_keypress: function(evt) {
+            text_keypress: function (evt) {
                 evt.stopPropagation();
                 //evt.preventDefault();
                 return false;
             },
-            text_paste: function(evt) {
+            text_paste: function (evt) {
                 evt.preventDefault();
-                document.execCommand("insertText", false,
-                    evt.clipboardData.getData("text"));
+                document.execCommand(
+                    "insertText",
+                    false,
+                    evt.clipboardData.getData("text")
+                );
                 grow_svg_for_element(textbox());
             },
-            floating_text_click: function(evt) {
+            floating_text_click: function (evt) {
                 if (target_is_scrollbar(evt)) {
                     return;
                 }
@@ -401,32 +460,35 @@ var canvas_events = (function() {
                 evt.preventDefault();
                 return false;
             },
-            floating_text_keypress: function(evt) {
+            floating_text_keypress: function (evt) {
                 //pdgui.post("leaving floating mode");
                 canvas_events.text();
                 //evt.stopPropagation();
                 //evt.preventDefault();
                 //return false;
             },
-            find_click: function(evt) {
+            find_click: function (evt) {
                 var t = document.getElementById("canvas_find_text").value;
                 if (t !== "") {
                     if (t === last_search_term) {
                         pdgui.pdsend(name, "findagain");
                     } else {
-                        pdgui.pdsend(name, "find",
-                        pdgui.encode_for_dialog(t),
-                        match_words_state ? "1" : "0");
+                        pdgui.pdsend(
+                            name,
+                            "find",
+                            pdgui.encode_for_dialog(t),
+                            match_words_state ? "1" : "0"
+                        );
                     }
                 }
                 last_search_term = t;
             },
-            find_keydown: function(evt) {
+            find_keydown: function (evt) {
                 if (evt.keyCode === 13) {
                     events.find_click(evt);
                 }
             },
-            scalar_draggable_mousemove: function(evt) {
+            scalar_draggable_mousemove: function (evt) {
                 var new_x = evt.pageX,
                     new_y = evt.pageY,
                     dx = new_x - last_draggable_x,
@@ -443,16 +505,26 @@ var canvas_events = (function() {
                     tx = minv.a * dx + minv.c * dy,
                     ty = minv.b * dx + minv.d * dy;
                 var obj = scalar_draggables[draggable_elem.id];
-                pdgui.pdsend(obj.cid, "scalar_event", obj.scalar_sym,
-                    obj.drawcommand_sym, obj.array_sym, obj.index,
-                    obj.event_name, dx, dy, tx, ty);
+                pdgui.pdsend(
+                    obj.cid,
+                    "scalar_event",
+                    obj.scalar_sym,
+                    obj.drawcommand_sym,
+                    obj.array_sym,
+                    obj.index,
+                    obj.event_name,
+                    dx,
+                    dy,
+                    tx,
+                    ty
+                );
                 last_draggable_x = new_x;
                 last_draggable_y = new_y;
             },
-            scalar_draggable_mouseup: function(evt) {
+            scalar_draggable_mouseup: function (evt) {
                 canvas_events.normal();
             },
-            iemgui_label_mousemove: function(evt) {
+            iemgui_label_mousemove: function (evt) {
                 // This is very convoluted.
                 // 1. In the generic mousedown handler we detect a click for a
                 //    label handle, red gop rect handle, or [cnv] resize anchor.
@@ -481,50 +553,51 @@ var canvas_events = (function() {
                 //      handle (which will eventually get erased by Pd anyway).
                 //      Anyhow, this is all very bad, but it works so it's
                 //      at least not the worst of all possible worlds.
-                var dx = (evt.pageX + svg_view.x) - last_draggable_x,
-                    dy = (evt.pageY + svg_view.y) - last_draggable_y,
+                var dx = evt.pageX + svg_view.x - last_draggable_x,
+                    dy = evt.pageY + svg_view.y - last_draggable_y,
                     handle_elem = document.querySelector(
-                        draggable_label ?
-                            ".move_handle" :
-                            ".cnv_resize_handle"
-                        ),
-                    target_id = (draggable_label ? "_l" : "_s") +
-                        handle_elem.parentNode.id.slice(0,-4).slice(1),
-                    is_canvas_gop_rect = document.
-                        getElementsByClassName("gop_drag_handle").length ?
-                        true : false;
+                        draggable_label ? ".move_handle" : ".cnv_resize_handle"
+                    ),
+                    target_id =
+                        (draggable_label ? "_l" : "_s") +
+                        handle_elem.parentNode.id.slice(0, -4).slice(1),
+                    is_canvas_gop_rect = document.getElementsByClassName(
+                        "gop_drag_handle"
+                    ).length
+                        ? true
+                        : false;
 
                 last_draggable_x = evt.pageX + svg_view.x;
                 last_draggable_y = evt.pageY + svg_view.y;
 
-                pdgui.pdsend(target_id, "_motion",
-                    (evt.pageX + svg_view.x),
-                    (evt.pageY + svg_view.y));
+                pdgui.pdsend(
+                    target_id,
+                    "_motion",
+                    evt.pageX + svg_view.x,
+                    evt.pageY + svg_view.y
+                );
             },
-            iemgui_label_mouseup: function(evt) {
+            iemgui_label_mouseup: function (evt) {
                 //pdgui.post("lifting the mousebutton on an iemgui label");
                 // Set last state (none doesn't count as a state)
                 //pdgui.post("previous state is "
                 //    + canvas_events.get_previous_state());
                 var label_handle = document.querySelector(".move_handle");
-                var cnv_resize_handle =
-                    document.querySelector(".cnv_resize_handle");
+                var cnv_resize_handle = document.querySelector(".cnv_resize_handle");
                 // Restore our cursor bindings for any drag handles that
                 // happen to exist
                 if (label_handle) {
-                    pdgui.toggle_drag_handle_cursors(label_handle,
-                        true, true);
+                    pdgui.toggle_drag_handle_cursors(label_handle, true, true);
                 }
                 if (cnv_resize_handle) {
-                    pdgui.toggle_drag_handle_cursors(cnv_resize_handle,
-                        false, true);
+                    pdgui.toggle_drag_handle_cursors(cnv_resize_handle, false, true);
                 }
                 canvas_events[canvas_events.get_previous_state()]();
             },
-            dropdown_menu_keydown: function(evt) {
+            dropdown_menu_keydown: function (evt) {
                 var select_elem = document.querySelector("#dropdown_list"),
                     li;
-                switch(evt.keyCode) {
+                switch (evt.keyCode) {
                     case 13:
                     case 32:
                         dropdown_index_to_pd(select_elem);
@@ -537,57 +610,59 @@ var canvas_events = (function() {
                         break;
                     case 38: // up
                         li = select_elem.querySelector(".highlighted");
-                        li = li.previousElementSibling ||
-                             li.parentElement.lastElementChild;
+                        li = li.previousElementSibling || li.parentElement.lastElementChild;
                         dropdown_highlight_elem(li, "up");
                         evt.preventDefault();
                         break;
                     case 40: // down
                         li = select_elem.querySelector(".highlighted");
-                        li = li.nextElementSibling ||
-                             li.parentElement.firstElementChild;
+                        li = li.nextElementSibling || li.parentElement.firstElementChild;
                         dropdown_highlight_elem(li, "down");
                         evt.preventDefault();
                         break;
                     default:
                 }
             },
-            dropdown_menu_keypress: function(evt) {
+            dropdown_menu_keypress: function (evt) {
                 var li_nodes = document.querySelectorAll("#dropdown_list li"),
                     string_array = [],
                     highlighted,
                     highlighted_index,
                     match,
                     offset;
-                highlighted = document
-                    .querySelector("#dropdown_list .highlighted");
+                highlighted = document.querySelector("#dropdown_list .highlighted");
                 if (highlighted) {
-                    highlighted_index =
-                        +document.querySelector("#dropdown_list .highlighted")
-                            .getAttribute("data-index");
+                    highlighted_index = +document
+                        .querySelector("#dropdown_list .highlighted")
+                        .getAttribute("data-index");
                     offset = highlighted_index + 1;
                 } else {
                     highlighted_index = 1;
                     offset = 2;
                 }
-                Array.prototype.forEach.call(li_nodes, function(e, i, a) {
+                Array.prototype.forEach.call(li_nodes, function (e, i, a) {
                     var s = a[(i + offset) % a.length];
                     string_array.push(s.textContent.trim());
                 });
                 match = string_array.indexOf(
-                    string_array.find(function(e) {
-                        return e.charAt(0).toLowerCase() ===
-                            String.fromCharCode(evt.charCode).toLowerCase();
-                }));
+                    string_array.find(function (e) {
+                        return (
+                            e.charAt(0).toLowerCase() ===
+                            String.fromCharCode(evt.charCode).toLowerCase()
+                        );
+                    })
+                );
                 if (match !== undefined) {
                     match = (match + offset) % li_nodes.length;
                     if (match !== highlighted_index) {
-                        dropdown_highlight_elem(li_nodes[match],
-                            match < highlighted_index ? "up" : "down");
+                        dropdown_highlight_elem(
+                            li_nodes[match],
+                            match < highlighted_index ? "up" : "down"
+                        );
                     }
                 }
             },
-            dropdown_menu_mousedown: function(evt) {
+            dropdown_menu_mousedown: function (evt) {
                 var select_elem = document.querySelector("#dropdown_list"),
                     in_dropdown = evt.target;
                 while (in_dropdown) {
@@ -597,20 +672,25 @@ var canvas_events = (function() {
                     in_dropdown = in_dropdown.parentNode;
                 }
                 // Allow scrollbar click and drag without closing the menu
-                if (in_dropdown &&
-                        evt.pageX - select_elem.offsetLeft >
-                        select_elem.clientWidth) {
+                if (
+                    in_dropdown &&
+                    evt.pageX - select_elem.offsetLeft > select_elem.clientWidth
+                ) {
                     return;
                 }
                 // Special case for OSX, where the scrollbar doesn't take
                 // up any extra space
-                if (nw.process.platform === "darwin"
-                    && (evt.target.id === "dropdown_list")) {
+                if (
+                    nw.process.platform === "darwin" &&
+                    evt.target.id === "dropdown_list"
+                ) {
                     return;
                 }
-                if (evt.target.parentNode
-                    && evt.target.parentNode.parentNode
-                    && evt.target.parentNode.parentNode.id === "dropdown_list") {
+                if (
+                    evt.target.parentNode &&
+                    evt.target.parentNode.parentNode &&
+                    evt.target.parentNode.parentNode.id === "dropdown_list"
+                ) {
                     dropdown_highlight_elem(evt.target);
                 }
                 // This selects whatever item is highlighted even
@@ -620,28 +700,30 @@ var canvas_events = (function() {
                 select_elem.style.setProperty("display", "none");
                 canvas_events.normal();
             },
-            dropdown_menu_mouseup: function(evt) {
+            dropdown_menu_mouseup: function (evt) {
                 var i, select_elem;
                 // This can be triggered if the user keeps the mouse down
                 // to highlight an element and releases the mouse button to
                 // choose that element
-                if (evt.target.parentNode
-                    && evt.target.parentNode.parentNode
-                    && evt.target.parentNode.parentNode.id === "dropdown_list") {
+                if (
+                    evt.target.parentNode &&
+                    evt.target.parentNode.parentNode &&
+                    evt.target.parentNode.parentNode.id === "dropdown_list"
+                ) {
                     select_elem = document.querySelector("#dropdown_list");
                     dropdown_index_to_pd(select_elem);
                     select_elem.style.setProperty("display", "none");
                     canvas_events.normal();
                 }
             },
-            dropdown_menu_wheel: function(evt) {
+            dropdown_menu_wheel: function (evt) {
                 // Here we generate bogus mouse coords so that
                 // we can break through the filter below if we're
                 // using the mouse wheel to scroll in the list.
                 last_dropdown_menu_x = Number.MIN_VALUE;
                 last_dropdown_menu_y = Number.MIN_VALUE;
             },
-            dropdown_menu_mousemove: function(evt) {
+            dropdown_menu_mousemove: function (evt) {
                 // For whatever reason, Chromium decides to trigger the
                 // mousemove/mouseenter/mouseover events if the element
                 // underneath it changes (or for mousemove, if the element
@@ -649,11 +731,15 @@ var canvas_events = (function() {
                 // the mouse position the entire time to filter out the
                 // true mousemove events from the ones Chromium generates
                 // when a scroll event changes the element under the mouse.
-                if (evt.pageX !== last_dropdown_menu_x
-                    || evt.pageY !== last_dropdown_menu_y) {
-                    if (evt.target.parentNode
-                        && evt.target.parentNode.parentNode
-                        && evt.target.parentNode.parentNode.id === "dropdown_list") {
+                if (
+                    evt.pageX !== last_dropdown_menu_x ||
+                    evt.pageY !== last_dropdown_menu_y
+                ) {
+                    if (
+                        evt.target.parentNode &&
+                        evt.target.parentNode.parentNode &&
+                        evt.target.parentNode.parentNode.id === "dropdown_list"
+                    ) {
                         dropdown_highlight_elem(evt.target);
                     } else {
                         dropdown_clear_highlight();
@@ -664,7 +750,7 @@ var canvas_events = (function() {
             }
         },
         utils = {
-            create_obj: function() {
+            create_obj: function () {
                 // Yes: I _really_ want .innerText and NOT .textContent
                 // here.  I want those newlines: although that isn't
                 // standard in Pd-Vanilla, Pd-l2ork uses and preserves
@@ -677,11 +763,9 @@ var canvas_events = (function() {
                 }
                 pdgui.pdsend(name, "obj_buftotext");
             }
-        }
-    ;
-
+        };
     return {
-        none: function() {
+        none: function () {
             var evt_name, prop;
             if (state !== "none") {
                 previous_state = state;
@@ -695,28 +779,43 @@ var canvas_events = (function() {
                 }
             }
         },
-        normal: function() {
+        normal: function () {
             canvas_events.none();
 
-            document.addEventListener("mousemove", events.mousemove, false);
+            document.addEventListener("mousemove", events.pointermove, false);
+            document.addEventListener("touchmove", events.pointermove, false);
+
             document.addEventListener("keydown", events.keydown, false);
             document.addEventListener("keypress", events.keypress, false);
             document.addEventListener("keyup", events.keyup, false);
-            document.addEventListener("mousedown", events.mousedown, false);
-            document.addEventListener("mouseup", events.mouseup, false);
+
+            document.addEventListener("mousedown", events.pointerdown, false);
+            document.addEventListener("touchstart", events.pointerdown, false);
+
+            document.addEventListener("mouseup", events.pointerup, false);
+            document.addEventListener("touchend", events.pointerup, false);
+
             state = "normal";
             set_edit_menu_modals(true);
         },
-        scalar_drag: function() {
+        scalar_drag: function () {
             // This scalar_drag is a prototype for moving more of the editing
             // environment directly to the GUI.  At the moment we're leaving
             // the other "normal" events live, since behavior like editmode
             // selection still happens from the Pd engine.
             //this.none();
-            document.addEventListener("mousemove", events.scalar_draggable_mousemove, false);
-            document.addEventListener("mouseup", events.scalar_draggable_mouseup, false);
+            document.addEventListener(
+                "mousemove",
+                events.scalar_draggable_mousemove,
+                false
+            );
+            document.addEventListener(
+                "mouseup",
+                events.scalar_draggable_mouseup,
+                false
+            );
         },
-        iemgui_label_drag: function() {
+        iemgui_label_drag: function () {
             // This is a workaround for dragging iemgui labels. Resizing iemguis
             // currently happens in Pd (canvas_doclick and canvas_motion). (Look
             // for MA_RESIZE.)
@@ -724,12 +823,15 @@ var canvas_events = (function() {
             // rectangle extends past the bbox that it reports to Pd.
             // Unfortunately that means a lot of work to treat it separately.
             canvas_events.none();
-            document.addEventListener("mousemove",
-                events.iemgui_label_mousemove, false);
-            document.addEventListener("mouseup",
-                events.iemgui_label_mouseup, false);
+            document.addEventListener(
+                "mousemove",
+                events.iemgui_label_mousemove,
+                false
+            );
+            pdgui.post("iemgui_label_drag");
+            document.addEventListener("mouseup", events.iemgui_label_mouseup, false);
         },
-        text: function() {
+        text: function () {
             canvas_events.none();
 
             document.addEventListener("mousemove", events.text_mousemove, false);
@@ -742,7 +844,7 @@ var canvas_events = (function() {
             state = "text";
             set_edit_menu_modals(false);
         },
-        floating_text: function() {
+        floating_text: function () {
             canvas_events.none();
             canvas_events.text();
             document.removeEventListener("mousedown", events.text_mousedown, false);
@@ -750,49 +852,73 @@ var canvas_events = (function() {
             document.removeEventListener("keypress", events.text_keypress, false);
             document.removeEventListener("mousemove", events.text_mousemove, false);
             document.addEventListener("click", events.floating_text_click, false);
-            document.addEventListener("keypress", events.floating_text_keypress, false);
+            document.addEventListener(
+                "keypress",
+                events.floating_text_keypress,
+                false
+            );
             document.addEventListener("mousemove", events.mousemove, false);
             state = "floating_text";
             set_edit_menu_modals(false);
         },
-        dropdown_menu: function() {
+        dropdown_menu: function () {
             canvas_events.none();
-            document.addEventListener("mousedown", events.dropdown_menu_mousedown, false);
+            document.addEventListener(
+                "mousedown",
+                events.dropdown_menu_mousedown,
+                false
+            );
             document.addEventListener("mouseup", events.dropdown_menu_mouseup, false);
-            document.addEventListener("mousemove", events.dropdown_menu_mousemove, false);
+            document.addEventListener(
+                "mousemove",
+                events.dropdown_menu_mousemove,
+                false
+            );
             document.addEventListener("keydown", events.dropdown_menu_keydown, false);
-            document.addEventListener("keypress", events.dropdown_menu_keypress, false);
-            document.querySelector("#dropdown_list")
+            document.addEventListener(
+                "keypress",
+                events.dropdown_menu_keypress,
+                false
+            );
+            document
+                .querySelector("#dropdown_list")
                 .addEventListener("wheel", events.dropdown_menu_wheel, false);
         },
-        search: function() {
+        search: function () {
             canvas_events.none();
             document.addEventListener("keydown", events.find_keydown, false);
             state = "search";
         },
-        register: function(n) {
+        register: function (n) {
             name = n;
         },
-        get_id: function() {
+        get_id: function () {
             return name;
         },
-        get_state: function() {
+        get_state: function () {
             return state;
         },
-        get_previous_state: function() {
+        get_previous_state: function () {
             return previous_state;
         },
-        create_obj: function() {
+        create_obj: function () {
             utils.create_obj();
         },
-        match_words: function(state) {
+        match_words: function (state) {
             match_words_state = state;
         },
-        find_reset: function() {
+        find_reset: function () {
             last_search_term = "";
         },
-        add_scalar_draggable: function(cid, tag, scalar_sym, drawcommand_sym,
-            event_name, array_sym, index) {
+        add_scalar_draggable: function (
+            cid,
+            tag,
+            scalar_sym,
+            drawcommand_sym,
+            event_name,
+            array_sym,
+            index
+        ) {
             scalar_draggables[tag] = {
                 cid: cid,
                 scalar_sym: scalar_sym,
@@ -802,22 +928,22 @@ var canvas_events = (function() {
                 index: index
             };
         },
-        remove_scalar_draggable: function(id) {
+        remove_scalar_draggable: function (id) {
             if (scalar_draggables[id]) {
                 scalar_draggables[id] = null;
             }
         },
-        save_and_close: function() {
+        save_and_close: function () {
             pdgui.pdsend(name, "menusave", 1);
         },
-        close_without_saving: function(cid, force) {
+        close_without_saving: function (cid, force) {
             pdgui.pdsend(name, "dirty 0");
             pdgui.pdsend(cid, "menuclose", force);
         },
-        close_save_dialog: function() {
+        close_save_dialog: function () {
             document.getElementById("save_before_quit").close();
         },
-        paste_from_pd_file: function(name, clipboard_data) {
+        paste_from_pd_file: function (name, clipboard_data) {
             var line, lines, i, pd_message;
             // This lets the user copy some Pd source file from another
             // application and paste the code directly into a canvas window
@@ -832,7 +958,9 @@ var canvas_events = (function() {
                 return;
             }
             if (!might_be_a_pd_file(clipboard_data)) {
-                pdgui.post("paste error: clipboard doesn't appear to contain valid Pd code");
+                pdgui.post(
+                    "paste error: clipboard doesn't appear to contain valid Pd code"
+                );
                 return;
             }
 
@@ -844,8 +972,10 @@ var canvas_events = (function() {
                 line = lines[i];
                 // process pd_message if it ends with a semicolon that
                 // isn't preceded by a backslash
-                if (line.slice(-1) === ";" &&
-                    (line.length < 2 || line.slice(-2, -1) !== "\\")) {
+                if (
+                    line.slice(-1) === ";" &&
+                    (line.length < 2 || line.slice(-2, -1) !== "\\")
+                ) {
                     if (pd_message === "") {
                         pd_message = line;
                     } else {
@@ -870,22 +1000,27 @@ var canvas_events = (function() {
             // add stuff to the existing buffer contents.)
             pdgui.pdsend(name, "reset_copyfromexternalbuffer");
         },
-        init: function() {
-            document.getElementById("saveDialog")
+        init: function () {
+            document
+                .getElementById("saveDialog")
                 .setAttribute("nwworkingdir", pdgui.get_pwd());
-            document.getElementById("fileDialog")
+            document
+                .getElementById("fileDialog")
                 .setAttribute("nwworkingdir", pdgui.get_pwd());
-            document.getElementById("fileDialog").setAttribute("accept",
-                Object.keys(pdgui.pd_filetypes).toString());
+            document
+                .getElementById("fileDialog")
+                .setAttribute("accept", Object.keys(pdgui.pd_filetypes).toString());
             // Dialog events -- these are set elsewhere now because of a bug
             // with nwworkingdir
-            document.querySelector("#saveDialog").addEventListener("change",
-                function(evt) {
+            document.querySelector("#saveDialog").addEventListener(
+                "change",
+                function (evt) {
                     pdgui.saveas_callback(name, evt.target.value, 0);
                     // reset value so that we can open the same file twice
                     evt.target.value = null;
                     console.log("tried to save something");
-                }, false
+                },
+                false
             );
             // Whoa-- huge workaround! Right now we're getting
             // the popup menu the way Pd Vanilla does it:
@@ -908,13 +1043,13 @@ var canvas_events = (function() {
             // and only pass a message to Pd when the user has clicked an item.
             // For now, however, we just turn off its default behavior and
             // control it with a bunch of complicated callbacks.
-            document.addEventListener("contextmenu", function(evt) {
+            document.addEventListener("contextmenu", function (evt) {
                 console.log("got a context menu evt...");
                 evt.preventDefault();
             });
 
             // Cut event
-            document.addEventListener("cut", function(evt) {
+            document.addEventListener("cut", function (evt) {
                 // This event doesn't currently get called because the
                 // nw menubar receives the event and doesn't propagate
                 // to the DOM. But if we add the ability to toggle menubar
@@ -923,7 +1058,7 @@ var canvas_events = (function() {
             });
 
             // Copy event
-            document.addEventListener("copy", function(evt) {
+            document.addEventListener("copy", function (evt) {
                 // On OSX, this event gets triggered when we're editing
                 // inside an object/message box. So we only forward the
                 // copy message to Pd if we're in a "normal" canvas state
@@ -936,7 +1071,7 @@ var canvas_events = (function() {
             // XXXTODO: Not sure whether this is even needed any more, as the
             // paste-from-clipboard functionality has been moved to its own menu
             // option. So this code may possibly be removed in the future. -ag
-            document.addEventListener("paste", function(evt) {
+            document.addEventListener("paste", function (evt) {
                 if (canvas_events.get_state() !== "normal") {
                     return;
                 }
@@ -945,9 +1080,9 @@ var canvas_events = (function() {
             });
 
             // MouseWheel event for zooming
-            document.addEventListener("wheel", function(evt) {
+            document.addEventListener("wheel", function (evt) {
                 var d = { deltaX: 0, deltaY: 0, deltaZ: 0 };
-                Object.keys(d).forEach(function(key) {
+                Object.keys(d).forEach(function (key) {
                     if (evt[key] < 0) {
                         d[key] = -1;
                     } else if (evt[key] > 0) {
@@ -963,8 +1098,7 @@ var canvas_events = (function() {
                 // Send a message on to Pd for the [mousewheel] legacy object
                 // (in the future we can refcount to prevent forwarding
                 // these messages when there's no extant receiver)
-                pdgui.pdsend(name, "legacy_mousewheel",
-                    d.deltaX, d.deltaY, d.deltaZ);
+                pdgui.pdsend(name, "legacy_mousewheel", d.deltaX, d.deltaY, d.deltaZ);
             });
 
             // The following is commented out because we have to set the
@@ -980,87 +1114,99 @@ var canvas_events = (function() {
             //        console.log("tried to open something\n\n\n\n\n\n\n\n");
             //    }, false
             //);
-            document.querySelector("#openpanel_dialog")
-                .addEventListener("change", function(evt) {
+            document.querySelector("#openpanel_dialog").addEventListener(
+                "change",
+                function (evt) {
                     var file_string = evt.target.value;
                     // reset value so that we can open the same file twice
                     evt.target.value = null;
                     pdgui.file_dialog_callback(file_string);
                     console.log("tried to openpanel something");
-                }, false
+                },
+                false
             );
-            document.querySelector("#savepanel_dialog")
-                .addEventListener("change", function(evt) {
+            document.querySelector("#savepanel_dialog").addEventListener(
+                "change",
+                function (evt) {
                     var file_string = evt.target.value;
                     // reset value so that we can open the same file twice
                     evt.target.value = null;
                     pdgui.file_dialog_callback(file_string);
                     console.log("tried to savepanel something");
-                }, false
+                },
+                false
             );
-            document.querySelector("#canvas_find_text")
-                .addEventListener("focusin", canvas_events.search, false
-            );
+            document
+                .querySelector("#canvas_find_text")
+                .addEventListener("focusin", canvas_events.search, false);
 
             // disable drag and drop for the time being
-            window.addEventListener("dragover", function (evt) {
-                evt.preventDefault();
-            }, false);
-            window.addEventListener("drop", function (evt) {
-                evt.preventDefault();
-            }, false);
+            window.addEventListener(
+                "dragover",
+                function (evt) {
+                    evt.preventDefault();
+                },
+                false
+            );
+            window.addEventListener(
+                "drop",
+                function (evt) {
+                    evt.preventDefault();
+                },
+                false
+            );
 
-            // Add placeholder text... this all needs to be collected into an 
+            // Add placeholder text... this all needs to be collected into an
             // add_events function similiar to the one in index.js
-            document.querySelector("#canvas_find_text").placeholder =
-                l("canvas.find.placeholder");
-            document.querySelector("#canvas_find_text").addEventListener("blur",
-                canvas_events.normal, false
+            document.querySelector("#canvas_find_text").placeholder = l(
+                "canvas.find.placeholder"
             );
-            document.querySelector("#canvas_find_button")
-                .addEventListener("click", events.find_click
-            );
+            document
+                .querySelector("#canvas_find_text")
+                .addEventListener("blur", canvas_events.normal, false);
+            document
+                .querySelector("#canvas_find_button")
+                .addEventListener("click", events.find_click);
             // We need to separate these into nw_window events and html5 DOM
             // events closing the Window this isn't actually closing the window
             // yet
-            gui.Window.get().on("close", function() {
+            gui.Window.get().on("close", function () {
                 pdgui.pdsend(name, "menuclose 0");
             });
             // update viewport size when window size changes
-            gui.Window.get().on("maximize", function() {
+            gui.Window.get().on("maximize", function () {
                 pdgui.gui_canvas_get_scroll(name);
             });
-            gui.Window.get().on("unmaximize", function() {
+            gui.Window.get().on("unmaximize", function () {
                 pdgui.gui_canvas_get_scroll(name);
             });
-            gui.Window.get().on("resize", function() {
+            gui.Window.get().on("resize", function () {
                 pdgui.gui_canvas_get_scroll(name);
             });
-            gui.Window.get().on("focus", function() {
+            gui.Window.get().on("focus", function () {
                 nw_window_focus_callback(name);
             });
-            gui.Window.get().on("blur", function() {
+            gui.Window.get().on("blur", function () {
                 nw_window_blur_callback(name);
             });
-            gui.Window.get().on("move", function(x, y) {
+            gui.Window.get().on("move", function (x, y) {
                 var w = gui.Window.get();
-                pdgui.pdsend(name, "setbounds", x, y,
-                    x + w.width, y + w.height);
+                pdgui.pdsend(name, "setbounds", x, y, x + w.width, y + w.height);
             });
             // set minimum window size
             gui.Window.get().setMinimumSize(150, 100);
         }
     };
-}());
+})();
 
 // Stop-gap translator. We copy/pasted this in each dialog, too. It
 // should be moved to pdgui.js
 function translate_form() {
-    var i
+    var i;
     var elements = document.querySelectorAll("[data-i18n]");
     for (i = 0; i < elements.length; i++) {
         var data = elements[i].dataset.i18n;
-        if (data.slice(0,7) === "[title]") {
+        if (data.slice(0, 7) === "[title]") {
             elements[i].title = l(data.slice(7));
         } else {
             elements[i].textContent = l(data);
@@ -1124,39 +1270,51 @@ function create_popup_menu(name) {
     var popup_menu = new gui.Menu();
     pdgui.add_popup(name, popup_menu);
 
-    popup_menu.append(new gui.MenuItem({
-        label: l("canvas.menu.props"),
-        click: function() {
-            pdgui.popup_action(name, 0);
-        }
-    }));
-    popup_menu.append(new gui.MenuItem({
-        label: l("canvas.menu.open"),
-        click: function() {
-            pdgui.popup_action(name, 1);
-        }
-    }));
-    popup_menu.append(new gui.MenuItem({
-        label: l("canvas.menu.help"),
-        click: function() {
-            pdgui.popup_action(name, 2);
-        }
-    }));
-    popup_menu.append(new gui.MenuItem({
-        type: "separator",
-    }));
-    popup_menu.append(new gui.MenuItem({
-        label: l("canvas.menu.front"),
-        click: function() {
-            pdgui.popup_action(name, 3);
-        }
-    }));
-    popup_menu.append(new gui.MenuItem({
-        label: l("canvas.menu.back"),
-        click: function() {
-            pdgui.popup_action(name, 4);
-        }
-    }));
+    popup_menu.append(
+        new gui.MenuItem({
+            label: l("canvas.menu.props"),
+            click: function () {
+                pdgui.popup_action(name, 0);
+            }
+        })
+    );
+    popup_menu.append(
+        new gui.MenuItem({
+            label: l("canvas.menu.open"),
+            click: function () {
+                pdgui.popup_action(name, 1);
+            }
+        })
+    );
+    popup_menu.append(
+        new gui.MenuItem({
+            label: l("canvas.menu.help"),
+            click: function () {
+                pdgui.popup_action(name, 2);
+            }
+        })
+    );
+    popup_menu.append(
+        new gui.MenuItem({
+            type: "separator"
+        })
+    );
+    popup_menu.append(
+        new gui.MenuItem({
+            label: l("canvas.menu.front"),
+            click: function () {
+                pdgui.popup_action(name, 3);
+            }
+        })
+    );
+    popup_menu.append(
+        new gui.MenuItem({
+            label: l("canvas.menu.back"),
+            click: function () {
+                pdgui.popup_action(name, 4);
+            }
+        })
+    );
 }
 
 function nw_undo_menu(undo_text, redo_text) {
@@ -1228,7 +1386,7 @@ function set_cord_inspector_checkbox(state) {
 }
 
 // stop-gap
-function menu_generic () {
+function menu_generic() {
     alert("Please implement this");
 }
 
@@ -1240,28 +1398,30 @@ function minit(menu_item, options) {
             // "none", in which case we don't call them. This is just a
             // hack, though-- it'd be a better UX to disable all menu items
             // when we're in the "none" state.
-            menu_item[key] = (key !== "click") ?
-                options[key] :
-                function() {
-                    if (canvas_events.get_state() !== "none") {
-                        options[key]();
-                    }
-            };
+            menu_item[key] =
+                key !== "click"
+                    ? options[key]
+                    : function () {
+                        if (canvas_events.get_state() !== "none") {
+                            options[key]();
+                        }
+                    };
         }
     }
 }
 
 function nw_create_patch_window_menus(gui, w, name) {
     // if we're on GNU/Linux or Windows, create the menus:
-    var m = canvas_menu = pd_menus.create_menu(gui);
+    var m = (canvas_menu = pd_menus.create_menu(gui));
 
     // File sub-entries
     // We explicitly enable these menu items because on OSX
     // the console menu disables them. (Same for Edit and Put menu)
     minit(m.file.new_file, { click: pdgui.menu_new });
     minit(m.file.open, {
-        click: function() {
-            var input, chooser,
+        click: function () {
+            var input,
+                chooser,
                 span = w.document.querySelector("#fileDialogSpan");
             // Complicated workaround-- see comment in build_file_dialog_string
             input = pdgui.build_file_dialog_string({
@@ -1277,7 +1437,7 @@ function nw_create_patch_window_menus(gui, w, name) {
             chooser = w.document.querySelector("#fileDialog");
             // Hack-- we have to set the event listener here because we
             // changed out the innerHTML above
-            chooser.onchange = function() {
+            chooser.onchange = function () {
                 var file_array = this.value;
                 // reset value so that we can open the same file twice
                 this.value = null;
@@ -1299,24 +1459,28 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.file.saveas, {
         enabled: true,
-        click: function (){
+        click: function () {
             pdgui.canvas_check_geometry(name);
             pdgui.menu_saveas(name);
         }
     });
     minit(m.file.print, {
         enabled: true,
-        click: function (){
+        click: function () {
             pdgui.canvas_check_geometry(name);
             pdgui.menu_print(name);
         }
     });
     minit(m.file.message, {
-        click: function() { pdgui.menu_send(name); }
+        click: function () {
+            pdgui.menu_send(name);
+        }
     });
     minit(m.file.close, {
         enabled: true,
-        click: function() { pdgui.menu_close(name); }
+        click: function () {
+            pdgui.menu_close(name);
+        }
     });
     minit(m.file.quit, {
         click: pdgui.menu_quit
@@ -1345,28 +1509,36 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.edit.cut, {
         enabled: true,
-        click: function () { pdgui.pdsend(name, "cut"); }
+        click: function () {
+            pdgui.pdsend(name, "cut");
+        }
     });
     minit(m.edit.copy, {
         enabled: true,
-        click: function () { pdgui.pdsend(name, "copy"); }
+        click: function () {
+            pdgui.pdsend(name, "copy");
+        }
     });
     minit(m.edit.paste, {
         enabled: true,
-        click: function () { pdgui.pdsend(name, "paste"); }
+        click: function () {
+            pdgui.pdsend(name, "paste");
+        }
     });
     minit(m.edit.paste_clipboard, {
         enabled: true,
         click: function () {
-	    var clipboard = nw.Clipboard.get();
-	    var text = clipboard.get('text');
-	    //pdgui.post("** paste from clipboard: "+text);
-	    canvas_events.paste_from_pd_file(name, text);
-	}
+            var clipboard = nw.Clipboard.get();
+            var text = clipboard.get("text");
+            //pdgui.post("** paste from clipboard: "+text);
+            canvas_events.paste_from_pd_file(name, text);
+        }
     });
     minit(m.edit.duplicate, {
         enabled: true,
-        click: function () { pdgui.pdsend(name, "duplicate"); }
+        click: function () {
+            pdgui.pdsend(name, "duplicate");
+        }
     });
     minit(m.edit.selectall, {
         enabled: true,
@@ -1387,7 +1559,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.edit.reselect, {
         enabled: true,
-        click: function() {
+        click: function () {
             // This is a bit complicated... menu item shortcuts receive
             // key events before the DOM, so we have to make sure to
             // filter out <ctrl-or-cmd-Enter> in the DOM eventhandler
@@ -1397,8 +1569,10 @@ function nw_create_patch_window_menus(gui, w, name) {
             // to "reselect".
             // As we move the editing functionality from the c code to
             // the GUI, this will get less complex.
-            if (canvas_events.get_state() === "floating_text" ||
-                canvas_events.get_state() === "text") {
+            if (
+                canvas_events.get_state() === "floating_text" ||
+                canvas_events.get_state() === "text"
+            ) {
                 canvas_events.text(); // anchor the object
                 canvas_events.create_obj();
             }
@@ -1407,15 +1581,21 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.edit.tidyup, {
         enabled: true,
-        click: function() { pdgui.pdsend(name, "tidy"); }
+        click: function () {
+            pdgui.pdsend(name, "tidy");
+        }
     });
     minit(m.edit.font, {
         enabled: true,
-        click: function () { pdgui.pdsend(name, "menufont"); }
+        click: function () {
+            pdgui.pdsend(name, "menufont");
+        }
     });
     minit(m.edit.cordinspector, {
         enabled: true,
-        click: function() { pdgui.pdsend(name, "magicglass 0"); }
+        click: function () {
+            pdgui.pdsend(name, "magicglass 0");
+        }
     });
     minit(m.edit.find, {
         click: function () {
@@ -1443,13 +1623,13 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.edit.findagain, {
         enabled: true,
-        click: function() {
+        click: function () {
             pdgui.pdsend(name, "findagain");
         }
     });
     minit(m.edit.finderror, {
         enabled: true,
-        click: function() {
+        click: function () {
             pdgui.pdsend("pd finderror");
         }
     });
@@ -1459,7 +1639,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.edit.editmode, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "editmode 0");
         }
@@ -1511,7 +1691,7 @@ function nw_create_patch_window_menus(gui, w, name) {
         }
     });
     minit(m.view.fullscreen, {
-        click: function() {
+        click: function () {
             var win = gui.Window.get();
             win.toggleFullscreen();
         }
@@ -1520,7 +1700,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     // Put menu
     minit(m.put.object, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "obj 0");
@@ -1528,7 +1708,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.message, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "msg 0");
@@ -1536,7 +1716,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.number, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "floatatom 0");
@@ -1544,7 +1724,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.symbol, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "symbolatom 0");
@@ -1552,7 +1732,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.comment, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "text 0");
@@ -1560,7 +1740,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.dropdown, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "dropdown 0");
@@ -1568,7 +1748,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.bang, {
         enabled: true,
-        click: function(e) {
+        click: function (e) {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "bng 0");
@@ -1576,7 +1756,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.toggle, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "toggle 0");
@@ -1584,7 +1764,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.number2, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "numbox 0");
@@ -1592,7 +1772,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.vslider, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "vslider 0");
@@ -1600,7 +1780,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.hslider, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "hslider 0");
@@ -1608,7 +1788,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.vradio, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "vradio 0");
@@ -1616,7 +1796,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.hradio, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "hradio 0");
@@ -1624,7 +1804,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.vu, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "vumeter 0");
@@ -1632,7 +1812,7 @@ function nw_create_patch_window_menus(gui, w, name) {
     });
     minit(m.put.cnv, {
         enabled: true,
-        click: function() {
+        click: function () {
             update_live_box();
             pdgui.pdsend(name, "dirty 1");
             pdgui.pdsend(name, "mycnv 0");
@@ -1649,73 +1829,73 @@ function nw_create_patch_window_menus(gui, w, name) {
     //});
     minit(m.put.array, {
         enabled: true,
-        click: function() {
-                update_live_box();
-                pdgui.pdsend(name, "dirty 1");
-                pdgui.pdsend(name, "menuarray");
-            }
+        click: function () {
+            update_live_box();
+            pdgui.pdsend(name, "dirty 1");
+            pdgui.pdsend(name, "menuarray");
+        }
     });
 
     // Window
     minit(m.win.nextwin, {
-        click: function() {
+        click: function () {
             pdgui.raise_next(name);
         }
     });
     minit(m.win.prevwin, {
-        click: function() {
+        click: function () {
             pdgui.raise_prev(name);
         }
     });
     minit(m.win.parentwin, {
         enabled: true,
-        click: function() {
+        click: function () {
             pdgui.pdsend(name, "findparent", 0);
         }
     });
     minit(m.win.visible_ancestor, {
         enabled: true,
-        click: function() {
+        click: function () {
             pdgui.pdsend(name, "findparent", 1);
         }
     });
     minit(m.win.pdwin, {
         enabled: true,
-        click: function() {
+        click: function () {
             pdgui.raise_pd_window();
         }
     });
 
     // Media menu
     minit(m.media.audio_on, {
-        click: function() {
+        click: function () {
             pdgui.pdsend("pd dsp 1");
         }
     });
     minit(m.media.audio_off, {
-        click: function() {
+        click: function () {
             pdgui.pdsend("pd dsp 0");
         }
     });
     minit(m.media.test, {
-        click: function() {
+        click: function () {
             pdgui.pd_doc_open("doc/7.stuff/tools", "testtone.pd");
         }
     });
     minit(m.media.loadmeter, {
-        click: function() {
+        click: function () {
             pdgui.pd_doc_open("doc/7.stuff/tools", "load-meter.pd");
         }
     });
 
     // Help menu
     minit(m.help.about, {
-        click: function() {
+        click: function () {
             pdgui.pd_doc_open("doc/about", "about.pd");
         }
     });
     minit(m.help.manual, {
-        click: function() {
+        click: function () {
             pdgui.pd_doc_open("doc/1.manual", "index.htm");
         }
     });
@@ -1723,27 +1903,27 @@ function nw_create_patch_window_menus(gui, w, name) {
         click: pdgui.open_search
     });
     minit(m.help.intro, {
-        click: function() {
+        click: function () {
             pdgui.pd_doc_open("doc/5.reference", "help-intro.pd");
         }
     });
     minit(m.help.l2ork_list, {
-        click: function() {
+        click: function () {
             pdgui.external_doc_open("http://disis.music.vt.edu/listinfo/l2ork-dev");
         }
     });
     minit(m.help.pd_list, {
-        click: function() {
+        click: function () {
             pdgui.external_doc_open("http://puredata.info/community/lists");
         }
     });
     minit(m.help.forums, {
-        click: function() {
+        click: function () {
             pdgui.external_doc_open("http://forum.pdpatchrepo.info/");
         }
     });
     minit(m.help.irc, {
-        click: function() {
+        click: function () {
             pdgui.external_doc_open("http://puredata.info/community/IRC");
         }
     });


### PR DESCRIPTION
Hey @agraef , 

This pull request contains changes to pd_canvas.js which enable touch support. In a nutshell, I have made slight modifications to the mouse interaction handlers to allow them to handle both mouse and touch events. As such, I have given them more generic names: pointermove, pointerdown, and pointerup, respectively. The motivation behind these changes is to allow our team to use purr-data on a capacitive touchscreen interface alongside the rest of our software. Thought others might find it useful!

Hope this pull request is kosher.

Best regards
Natalie